### PR TITLE
dynamic distro name

### DIFF
--- a/bin/fetch
+++ b/bin/fetch
@@ -5,7 +5,7 @@
 #
 
 title="$(whoami) @ $(hostname)"
-os="arch linux"
+os="$(cat /etc/*release | grep  -h "^NAME" | grep -o '".*"' | sed 's/"//g')"
 kernel="$(uname -r -o)"
 packages="$(pacman -Q | wc -l)"
 wm=$(wmctrl -m | grep -o "Name: .*" | cut -f2- -d' ')


### PR DESCRIPTION
To read OS/Distro name dynamically, I think it would take a bit(read: a lot) longer code, with many different cases, since there is no universal way of checking\* and every distro/OS stores it differently. BUT most of them store it at /etc/$distro_name-release.

This isn't the optimal solution, but before it could display only "arch", now it works on arch + potentially on other distros(I would love to test it, but just realized all my machines are running on arch  ;-;  | I might have something debian-based on VM, will look into it) so there won't be much harm with it.

You could possibly take code from screenfetch or other scripts but, where is the fun in that ? :D

*there actually is a way, but it would require a dependancy. inxi -S would display the needed info on any distro. But dependencies kinda suck
